### PR TITLE
fix(ai): compatible OpenAI mode + Node runtime for streaming

### DIFF
--- a/pho-chat/README.md
+++ b/pho-chat/README.md
@@ -46,3 +46,6 @@ To learn more about Next.js, take a look at the following resources:
 ## Deploy on Vercel
 
 See [Next.js deployment docs](https://nextjs.org/docs/app/building-your-application/deploying) and ensure environment variables are set in Vercel.
+
+
+Production deploy trigger 2.

--- a/pho-chat/src/app/api/ai/stream/route.ts
+++ b/pho-chat/src/app/api/ai/stream/route.ts
@@ -3,11 +3,13 @@ import { streamText } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 
 export const dynamic = "force-dynamic"; // ensure streaming works in dev/prod
+export const runtime = "nodejs"; // ensure Node runtime for streaming
 
 const apiKey = process.env.AI_GATEWAY_KEY || process.env.NEXT_PUBLIC_AI_GATEWAY_KEY;
 const baseURL = process.env.AI_GATEWAY_BASE_URL || process.env.NEXT_PUBLIC_AI_GATEWAY_BASE_URL;
 
-const openai = createOpenAI({ apiKey, baseURL });
+// Use 'compatible' to hit /chat/completions for OpenAI-compatible gateways
+const openai = createOpenAI({ apiKey, baseURL, compatibility: "compatible" });
 
 function json(status: number, data: any) {
   return NextResponse.json(data, { status });


### PR DESCRIPTION
- Force Node runtime for API route streaming
- Use OpenAI-compatible mode for gateway endpoints (chat.completions)

This should resolve 405 responses from /v1/openai/responses when using the Vercel AI Gateway.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author