### PR TITLE
fix(ai): force chat.completions path; add debug log

### DIFF
--- a/pho-chat/README.md
+++ b/pho-chat/README.md
@@ -46,3 +46,6 @@ To learn more about Next.js, take a look at the following resources:
 ## Deploy on Vercel
 
 See [Next.js deployment docs](https://nextjs.org/docs/app/building-your-application/deploying) and ensure environment variables are set in Vercel.
+
+
+Production deploy trigger 2.

--- a/pho-chat/src/app/api/ai/stream/route.ts
+++ b/pho-chat/src/app/api/ai/stream/route.ts
@@ -3,11 +3,13 @@ import { streamText } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 
 export const dynamic = "force-dynamic"; // ensure streaming works in dev/prod
+export const runtime = "nodejs"; // ensure Node runtime for streaming
 
 const apiKey = process.env.AI_GATEWAY_KEY || process.env.NEXT_PUBLIC_AI_GATEWAY_KEY;
 const baseURL = process.env.AI_GATEWAY_BASE_URL || process.env.NEXT_PUBLIC_AI_GATEWAY_BASE_URL;
 
-const openai = createOpenAI({ apiKey, baseURL });
+// Use 'compatible' to hit /chat/completions for OpenAI-compatible gateways
+const openai = createOpenAI({ apiKey, baseURL, compatibility: "compatible" });
 
 function json(status: number, data: any) {
   return NextResponse.json(data, { status });

--- a/pho-chat/src/app/api/ai/stream/route.ts
+++ b/pho-chat/src/app/api/ai/stream/route.ts
@@ -35,7 +35,8 @@ export async function POST(req: Request) {
       });
     }
 
-    const result = await streamText({ model: openai(model), prompt });
+    console.log("[AI] streamText", { model, using: "chat.completions", baseURL });
+    const result = await streamText({ model: openai.chat(model), prompt });
 
     // Stream plain text chunks; ignore non-text events
     return result.toTextStreamResponse();


### PR DESCRIPTION
- Use openai.chat(model) so the AI SDK calls /chat/completions instead of /responses
- Adds a debug log for model and baseURL


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author