### PR TITLE
feat(ai): add /api/ai/test endpoint; UI auto-create session; fix stream fetch visibility

### DIFF
--- a/pho-chat/README.md
+++ b/pho-chat/README.md
@@ -46,3 +46,6 @@ To learn more about Next.js, take a look at the following resources:
 ## Deploy on Vercel
 
 See [Next.js deployment docs](https://nextjs.org/docs/app/building-your-application/deploying) and ensure environment variables are set in Vercel.
+
+
+Production deploy trigger 2.

--- a/pho-chat/src/app/api/ai/stream/route.ts
+++ b/pho-chat/src/app/api/ai/stream/route.ts
@@ -3,11 +3,13 @@ import { streamText } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 
 export const dynamic = "force-dynamic"; // ensure streaming works in dev/prod
+export const runtime = "nodejs"; // ensure Node runtime for streaming
 
 const apiKey = process.env.AI_GATEWAY_KEY || process.env.NEXT_PUBLIC_AI_GATEWAY_KEY;
 const baseURL = process.env.AI_GATEWAY_BASE_URL || process.env.NEXT_PUBLIC_AI_GATEWAY_BASE_URL;
 
-const openai = createOpenAI({ apiKey, baseURL });
+// Use 'compatible' to hit /chat/completions for OpenAI-compatible gateways
+const openai = createOpenAI({ apiKey, baseURL, compatibility: "compatible" });
 
 function json(status: number, data: any) {
   return NextResponse.json(data, { status });

--- a/pho-chat/src/app/api/ai/stream/route.ts
+++ b/pho-chat/src/app/api/ai/stream/route.ts
@@ -35,7 +35,8 @@ export async function POST(req: Request) {
       });
     }
 
-    const result = await streamText({ model: openai(model), prompt });
+    console.log("[AI] streamText", { model, using: "chat.completions", baseURL });
+    const result = await streamText({ model: openai.chat(model), prompt });
 
     // Stream plain text chunks; ignore non-text events
     return result.toTextStreamResponse();

--- a/pho-chat/src/app/api/ai/test/route.ts
+++ b/pho-chat/src/app/api/ai/test/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { createOpenAI } from "@ai-sdk/openai";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const apiKey = process.env.AI_GATEWAY_KEY || process.env.NEXT_PUBLIC_AI_GATEWAY_KEY;
+const baseURL = process.env.AI_GATEWAY_BASE_URL || process.env.NEXT_PUBLIC_AI_GATEWAY_BASE_URL;
+
+const openai = createOpenAI({ apiKey, baseURL });
+
+export async function GET() {
+  try {
+    const resp = await fetch(`${(baseURL?.replace(/\/$/, "")) || "https://ai-gateway.vercel.sh/v1"}/models`, {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      cache: "no-store",
+    });
+    const text = await resp.text();
+    return NextResponse.json({ ok: resp.ok, status: resp.status, preview: text.slice(0, 200) });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e?.message || String(e) }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { model = "gpt-4o-mini", prompt = "Say hello in one short sentence." } = await req.json();
+    const resp = await fetch(`${(baseURL?.replace(/\/$/, "")) || "https://ai-gateway.vercel.sh/v1"}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({ model, messages: [{ role: "user", content: prompt }] }),
+    });
+    const data = await resp.json().catch(() => null);
+    return NextResponse.json({ ok: resp.ok, status: resp.status, data });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e?.message || String(e) }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
- Add GET/POST /api/ai/test non-streaming endpoint for quick verification
- Client: auto-create session if missing when sending a message, so Send always triggers a POST /api/ai/stream
- This makes debugging easier and avoids empty UI when no session is created

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author