### PR TITLE
feat(ui): Enter to send; Ctrl/Cmd+Enter for newline

### DIFF
--- a/pho-chat/src/app/chat/page.tsx
+++ b/pho-chat/src/app/chat/page.tsx
@@ -225,7 +225,19 @@ function ChatPageInner() {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
+              if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                // Ctrl/Cmd + Enter => explicit newline
+                e.preventDefault();
+                setInput((prev) => `${prev}\n`);
+                return;
+              }
+              if (e.key === "Enter" && e.shiftKey) {
+                // Shift+Enter is disabled (no newline, no send)
+                e.preventDefault();
+                return;
+              }
+              if (e.key === "Enter") {
+                // Plain Enter => send
                 e.preventDefault();
                 if (!sending && !sendGuardRef.current && input.trim()) {
                   handleSend();


### PR DESCRIPTION
- Enter sends the message
- Ctrl/Cmd+Enter inserts a newline
- Shift+Enter is disabled (per request)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated chat input keyboard behavior:
    * Enter sends the message when not already sending and the input isn’t empty.
    * Ctrl/Cmd + Enter inserts a newline without sending.
    * Shift + Enter no longer inserts a newline.
  * Enhanced safeguards to prevent duplicate sends while a message is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->