### PR TITLE
feat(ui): Toast provider + message skeleton + copy toast

### DIFF
--- a/pho-chat/src/app/chat/page.tsx
+++ b/pho-chat/src/app/chat/page.tsx
@@ -2,8 +2,12 @@
 
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
+import { useToast } from "@/components/ui/toast";
+
 import * as React from "react";
 import { useSearchParams } from "next/navigation";
+import { Skeleton } from "@/components/ui/skeleton";
+
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -27,14 +31,22 @@ function SessionMessages({ sessionId }: { sessionId: string | null }) {
     "functions/getChatSession:getChatSession" as any,
     (sessionId ? { sessionId } : "skip") as any
   );
+  const loading = sessionId && !session;
   const messages: ChatMessage[] = (session as any)?.messages ?? [];
   if (!sessionId) return null;
   return (
     <>
-      {messages.length === 0 && (
+      {loading && (
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-3/5" />
+        </div>
+      )}
+      {!loading && messages.length === 0 && (
         <p className="text-sm text-muted-foreground">No messages yet. Start the conversation!</p>
       )}
-      {messages.map((m) => (
+      {!loading && messages.map((m) => (
         <div key={m.id} className="text-sm">
           <span className="font-medium mr-2">{m.role}:</span>
           <span className="whitespace-pre-wrap">{m.content}</span>
@@ -55,6 +67,8 @@ function ChatPageInner() {
   const [streamingText, setStreamingText] = React.useState<string>("");
   const [sending, setSending] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | null>(null);
+
+  const { success } = useToast();
 
   // New session form state
   const [newUserId, setNewUserId] = React.useState<string>("");
@@ -325,7 +339,7 @@ function ChatPageInner() {
 
           <div className="flex items-center justify-between text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
-              <Button size="sm" variant="outline" onClick={async () => { await navigator.clipboard.writeText(streamingText); setCopied(true); setTimeout(()=>setCopied(false), 1200); }} disabled={!streamingText}>
+              <Button size="sm" variant="outline" onClick={async () => { await navigator.clipboard.writeText(streamingText); setCopied(true); success("Copied"); setTimeout(()=>setCopied(false), 1200); }} disabled={!streamingText}>
                 {copied ? "Copied!" : "Copy last reply"}
               </Button>
               <Button size="sm" variant="secondary" onClick={handleNewChat}>

--- a/pho-chat/src/app/layout.tsx
+++ b/pho-chat/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 
 // Example shadcn/ui providers imported for ease of use across the app
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { ToastProvider } from '@/components/ui/toast';
 import { ConvexProviderClient } from '@/components/providers/convex-provider';
 
 
@@ -33,7 +34,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ConvexProviderClient>
-          <TooltipProvider>{children}</TooltipProvider>
+          <ToastProvider>
+            <TooltipProvider>{children}</TooltipProvider>
+          </ToastProvider>
         </ConvexProviderClient>
       </body>
     </html>

--- a/pho-chat/src/components/ui/skeleton.tsx
+++ b/pho-chat/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+

--- a/pho-chat/src/components/ui/toast.tsx
+++ b/pho-chat/src/components/ui/toast.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+
+type ToastItem = {
+  id: string;
+  message: string;
+  variant?: "default" | "success" | "error";
+  duration?: number; // ms
+};
+
+const ToastContext = React.createContext<{
+  push: (t: Omit<ToastItem, "id">) => void;
+} | null>(null);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = React.useState<ToastItem[]>([]);
+
+  const push = React.useCallback((t: Omit<ToastItem, "id">) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const item: ToastItem = {
+      id,
+      duration: 1800,
+      variant: "default",
+      ...t,
+    };
+    setItems((prev) => [...prev, item]);
+    const timeout = setTimeout(() => {
+      setItems((prev) => prev.filter((x) => x.id !== id));
+    }, item.duration);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ push }}>
+      {children}
+      <Toaster items={items} onClose={(id) => setItems((prev) => prev.filter((x) => x.id !== id))} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = React.useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return {
+    push: ctx.push,
+    success: (message: string, duration = 1800) => ctx.push({ message, duration, variant: "success" }),
+    error: (message: string, duration = 2200) => ctx.push({ message, duration, variant: "error" }),
+  };
+}
+
+export function Toaster({ items, onClose }: { items: ToastItem[]; onClose: (id: string) => void }) {
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-[100] flex w-[calc(100%-2rem)] max-w-sm flex-col gap-2">
+      {items.map((t) => (
+        <div
+          key={t.id}
+          className={
+            "pointer-events-auto rounded-md border shadow-md px-3 py-2 text-sm bg-background/95 backdrop-blur " +
+            (t.variant === "success"
+              ? "border-green-600/30 text-green-900 dark:text-green-200"
+              : t.variant === "error"
+              ? "border-red-600/30 text-red-900 dark:text-red-200"
+              : "border-border text-foreground")
+          }
+          role="status"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <span>{t.message}</span>
+            <button
+              onClick={() => onClose(t.id)}
+              className="rounded px-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
- Add ToastProvider and useToast hook
- Wire provider in layout
- Add Skeleton component and show loading state while messages load
- Copy last reply triggers toasts


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Toast notifications for success and error messages with auto-dismiss and manual close.
  - Loading skeletons appear while chat sessions are fetching.
  - “Copied” toast when using the Copy last reply action.
  - Clear empty state message: “No messages yet...” when a chat has no content.
  - Global toast support integrated across the app so notifications render consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->