### PR TITLE
feat: PayOS checkout create-order endpoint + return flow wiring

### DIFF
--- a/pho-chat/convex/_generated/api.d.ts
+++ b/pho-chat/convex/_generated/api.d.ts
@@ -26,6 +26,10 @@ import type * as index from "../index.js";
 import type * as revenuecat from "../revenuecat.js";
 import type * as types from "../types.js";
 import type * as users from "../users.js";
+import type * as orders from "../orders.js";
+import type * as payos from "../payos.js";
+import type * as reconcile from "../reconcile.js";
+
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -49,6 +53,10 @@ declare const fullApi: ApiFromModules<{
   revenuecat: typeof revenuecat;
   types: typeof types;
   users: typeof users;
+  orders: typeof orders;
+  payos: typeof payos;
+  reconcile: typeof reconcile;
+
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/pho-chat/convex/functions/handleWebhook.ts
+++ b/pho-chat/convex/functions/handleWebhook.ts
@@ -57,6 +57,7 @@ export const internalHandleWebhook = internalMutation({
           status: "succeeded",
           provider: "revenuecat",
           created_at: Date.now(),
+          receipts: body,
         });
       }
     } else if (provider === "qr") {
@@ -71,6 +72,7 @@ export const internalHandleWebhook = internalMutation({
           status,
           provider: "qr",
           created_at: Date.now(),
+          receipts: body,
         });
       }
     }

--- a/pho-chat/src/app/api/checkout/create-order/route.ts
+++ b/pho-chat/src/app/api/checkout/create-order/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest } from "next/server";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../../../../convex/_generated/api";
+import { getPayOS } from "@/lib/payos";
+import { logger } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function genOrderCode(): number {
+  // Generate a 15-digit-ish numeric code within JS safe range
+  const now = Date.now();
+  const rand = Math.floor(Math.random() * 1000);
+  // e.g. seconds since epoch * 1000 + random (keeps it <= ~13 digits)
+  return Math.floor(now / 1000) * 1000 + rand;
+}
+
+function baseUrlFrom(req: NextRequest): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL;
+  if (envUrl) return envUrl.replace(/\/$/, "");
+  const proto = (req.headers.get("x-forwarded-proto") || "https").split(",")[0].trim();
+  const host = req.headers.get("x-forwarded-host") || req.headers.get("host") || "localhost:3000";
+  return `${proto}://${host}`;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId, amount, description } = await req.json();
+
+    if (typeof amount !== "number" || amount <= 0) {
+      return new Response(JSON.stringify({ error: "Invalid amount" }), { status: 400 });
+    }
+
+    const user = typeof userId === "string" ? userId : "guest";
+    const orderCode = genOrderCode();
+
+    const convex = new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL || "");
+    // Create or reuse a pending order in our DB first
+    const orderId = await convex.mutation(api.orders.createOrReusePending, {
+      userId: user,
+      amount,
+      currency: "VND",
+      description: typeof description === "string" ? description : undefined,
+      orderCode,
+      provider: "payos",
+      metadata: undefined,
+    });
+
+    const appBase = baseUrlFrom(req);
+    const redirectPath = `/orders/${orderId}`;
+    const returnUrl = `${appBase}/payos/return?orderCode=${orderCode}&redirect=${encodeURIComponent(redirectPath)}`;
+    const cancelUrl = `${appBase}${redirectPath}`;
+
+    const payos = getPayOS();
+    const res = await payos.paymentRequests.create({
+      orderCode,
+      amount,
+      description: typeof description === "string" ? description : `Order ${orderCode}`,
+      returnUrl,
+      cancelUrl,
+    } as any);
+
+    const checkoutUrl = (res as any)?.checkoutUrl || (res as any)?.data?.checkoutUrl || "";
+    const paymentLinkId = (res as any)?.paymentLinkId || (res as any)?.data?.paymentLinkId;
+
+    try {
+      await convex.mutation(api.orders.attachCheckoutInfo, {
+        orderCode,
+        paymentLinkId,
+        checkoutUrl,
+      });
+    } catch (e: any) {
+      logger.error("Failed to attach checkout info", { orderCode, error: e?.message || String(e) });
+    }
+
+    logger.info("Order created & PayOS link generated", { orderCode, amount });
+
+    return new Response(
+      JSON.stringify({ orderId, orderCode, checkoutUrl, redirect: redirectPath }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (e: any) {
+    logger.error("create-order error", { error: e?.message || String(e) });
+    return new Response(
+      JSON.stringify({ error: e?.message || "Failed to create order" }),
+      { status: 500 }
+    );
+  }
+}
+

--- a/pho-chat/src/app/api/payos/webhook/route.ts
+++ b/pho-chat/src/app/api/payos/webhook/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
     try {
       raw = await req.text();
     } catch (err: any) {
-      logger.warn?.('Webhook body read failed; treating as healthcheck', { error: err?.message || String(err) });
+      logger.info('Webhook body read failed; treating as healthcheck', { error: err?.message || String(err) });
       return new Response(JSON.stringify({ ok: true, healthcheck: true }), { status: 200 });
     }
     if (!raw?.trim() || !contentType.includes('application/json')) {
@@ -26,7 +26,7 @@ export async function POST(req: NextRequest) {
     try {
       body = JSON.parse(raw);
     } catch (err: any) {
-      logger.warn?.('Webhook JSON parse failed; treating as healthcheck', { error: err?.message || String(err) });
+      logger.info('Webhook JSON parse failed; treating as healthcheck', { error: err?.message || String(err) });
       return new Response(JSON.stringify({ ok: true, healthcheck: true }), { status: 200 });
     }
 


### PR DESCRIPTION
- Add /api/checkout/create-order API (Next.js App Router)
  - Server generates numeric orderCode
  - Creates/updates pending order in Convex (orders.createOrReusePending)
  - Uses official payOS Node SDK (@payos/node) to create payment link
  - Stores checkoutUrl/paymentLinkId via orders.attachCheckoutInfo
  - Returns { orderId, orderCode, checkoutUrl, redirect }
- Integrates with existing /checkout page which calls this endpoint
- Return URL points to /payos/return and redirects to /orders/<orderId> after success

Env vars used: PAYOS_CLIENT_ID, PAYOS_API_KEY, PAYOS_CHECKSUM_KEY, NEXT_PUBLIC_CONVEX_URL, optional NEXT_PUBLIC_APP_URL.

This PR complements the webhook healthcheck hotfix (PR #31). After both are merged and deployed, end-to-end PayOS flow is enabled (create -> return -> webhook).


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author