### PR TITLE
fix(next): remove revalidate/dynamic exports from client pages to fix Next.js build error

### DIFF
--- a/pho-chat/src/app/admin/page.tsx
+++ b/pho-chat/src/app/admin/page.tsx
@@ -1,6 +1,5 @@
 "use client";
-export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+
 
 
 import { useQuery } from "convex/react";

--- a/pho-chat/src/app/chat/page.tsx
+++ b/pho-chat/src/app/chat/page.tsx
@@ -1,6 +1,5 @@
 "use client";
-export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+
 
 
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";


### PR DESCRIPTION
This PR fixes a production build/runtime error caused by exporting ISR options (revalidate/dynamic) from Client Components.

Problem
- Next.js App Router requires `export const revalidate` and `export const dynamic` to be defined in server files. Exporting them from a `"use client"` file turns them into client-proxy functions at build/runtime, which Next rejects:
  > Invalid revalidate value "function(){...}" on "/chat", must be a non-negative number or false

Changes
- src/app/chat/page.tsx: remove `export const dynamic = 'force-dynamic'` and `export const revalidate = 0`
- src/app/admin/page.tsx: remove `export const dynamic = 'force-dynamic'` and `export const revalidate = 0`

Notes
- Global settings are already defined server-side in src/app/metadata.ts:
  - `export const dynamic = 'force-dynamic'`
  - `export const revalidate = 0`
- Verified locally: `npm run build` succeeds.

After merge
- Vercel will deploy main. The /chat page will no longer crash the build.
- PayOS webhook validation will remain healthy (GET/HEAD/POST = 200).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Corrected rendering behavior for the Admin and Chat pages to align with client-component defaults, improving reliability and avoiding unexpected caching issues.

- Chores
  - Cleaned up obsolete configuration on select pages to reduce confusion and potential build warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->